### PR TITLE
Story/DFCC-1249: Documentation and amendments

### DIFF
--- a/DFC.App.ContactUs.UI.FunctionalTests/AfterScenario.cs
+++ b/DFC.App.ContactUs.UI.FunctionalTests/AfterScenario.cs
@@ -39,18 +39,6 @@ namespace DFC.App.ContactUs
         }
 
         [AfterScenario(Order = 1)]
-        public void InformBrowserStackOnFailure()
-        {
-            if (this.Context.TestError != null)
-            {
-                if (this.Context.GetHelperLibrary<AppSettings>().BrowserHelper.IsExecutingInBrowserStack())
-                {
-                    this.Context.GetHelperLibrary<AppSettings>().BrowserStackHelper.SendMessage("failed", this.Context.TestError.Message);
-                }
-            }
-        }
-
-        [AfterScenario(Order = 2)]
         public void DisposeWebDriver()
         {
             if (!this.Context.GetHelperLibrary<AppSettings>().BrowserHelper.IsExecutingInBrowserStack())

--- a/DFC.App.ContactUs.UI.FunctionalTests/AfterScenario.cs
+++ b/DFC.App.ContactUs.UI.FunctionalTests/AfterScenario.cs
@@ -31,10 +31,7 @@ namespace DFC.App.ContactUs
         {
             if (this.Context.TestError != null)
             {
-                if (this.Context.GetSettingsLibrary<AppSettings>().AppSettings.TakeScreenshots)
-                {
-                    this.Context.GetHelperLibrary<AppSettings>().ScreenshotHelper.TakeScreenshot(this.Context);
-                }
+                this.Context.GetHelperLibrary<AppSettings>().ScreenshotHelper.TakeScreenshot(this.Context);
             }
         }
 

--- a/DFC.App.ContactUs.UI.FunctionalTests/BeforeScenario.cs
+++ b/DFC.App.ContactUs.UI.FunctionalTests/BeforeScenario.cs
@@ -50,17 +50,6 @@ namespace DFC.App.ContactUs
             webDriver.Manage().Window.Maximize();
             webDriver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(settingsLibrary.TestExecutionSettings.TimeoutSettings.PageNavigation);
             webDriver.SwitchTo().Window(webDriver.CurrentWindowHandle);
-
-            if (new BrowserHelper(settingsLibrary.BrowserSettings.BrowserName).IsExecutingInBrowserStack())
-            {
-                this.Context.SetWebDriver(webDriver as RemoteWebDriver);
-                var capabilities = (this.Context.GetWebDriver() as RemoteWebDriver).Capabilities;
-                var overriddenBrowserName = capabilities["browserName"] as string;
-                var overriddenBrowserVersion = capabilities["browserVersion"] as string;
-                settingsLibrary.BrowserSettings.BrowserName = overriddenBrowserName;
-                settingsLibrary.BrowserSettings.BrowserVersion = overriddenBrowserVersion;
-            }
-
             this.Context.SetWebDriver(webDriver);
         }
 

--- a/DFC.App.ContactUs.UI.FunctionalTests/DFC.App.ContactUs.UI.FunctionalTests.csproj
+++ b/DFC.App.ContactUs.UI.FunctionalTests/DFC.App.ContactUs.UI.FunctionalTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DFC.TestAutomation.UI" Version="1.0.74" />
+    <PackageReference Include="DFC.TestAutomation.UI" Version="1.0.86" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/DFC.App.ContactUs.UI.FunctionalTests/Model/AppSettings.cs
+++ b/DFC.App.ContactUs.UI.FunctionalTests/Model/AppSettings.cs
@@ -10,10 +10,6 @@ namespace DFC.App.ContactUs.Model
 {
     internal class AppSettings : IAppSettings
     {
-        public string AppName { get; set; }
-
         public Uri AppUrl { get; set; }
-
-        public bool TakeScreenshots { get; set; }
     }
 }

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -26,11 +26,9 @@
     "AppUrl": "__ProjectSettings.AppUrl__"
   },
   "TestExecutionSettings": {
-    "TakeScreenshots": "__TestExecutionSettings.TakeScreenshots__",
     "TimeoutSettings": {
       "PageNavigation": "__TestExecutionSettings.TimeoutSettings.PageNavigation__",
-      "ImplicitWait": "__TestExecutionSettings.TimeoutSettings.ImplicitWait__",
-      "CommandTimeout": "__TestExecutionSettings.TimeoutSettings.CommandTimeout__"
+      "ImplicitWait": "__TestExecutionSettings.TimeoutSettings.ImplicitWait__"
     },
     "RetrySettings": {
       "NumberOfRetries": "__TestExecutionSettings.RetrySettings.NumberOfRetries__",

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -15,7 +15,6 @@
     "BrowserVersion": "__BrowserStackSettings.BrowserVersion__",
     "ScreenResolution": "__BrowserStackSettings.ScreenResolution__",
     "Project": "__BrowserStackSettings.Project__",
-    "Build": "__BrowserStackSettings.Build__",
     "EnableDebug": __BrowserStackSettings.EnableDebug__,
     "EnableNetworkLogs": __BrowserStackSettings.EnableNetworkLogs__,
     "RecordVideo": __BrowserStackSettings.RecordVideo__,

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -9,17 +9,19 @@
     "Proxy": "__BrowserSettings.Proxy__"
   },
   "BrowserStackSettings": {
-    "EnableNetworkLogs": "__BrowserStackSettings.EnableNetworkLogs__",
+    "OperatingSystem": "__BrowserStackSettings.OperatingSystem__",
+    "OperatingSystemVersion": "__BrowserStackSettings.OperatingSystemVersion__",
+    "BrowserName": "__BrowserStackSettings.BrowserName__",
+    "BrowserVersion": "__BrowserStackSettings.BrowserVersion__",
+    "ScreenResolution": "__BrowserStackSettings.ScreenResolution__",
+    "Project": "__BrowserStackSettings.Project__",
+    "Build": "__BrowserStackSettings.Build__",
+    "EnableDebug": __BrowserStackSettings.EnableDebug__,
+    "EnableNetworkLogs": __BrowserStackSettings.EnableNetworkLogs__,
+    "RecordVideo": __BrowserStackSettings.RecordVideo__,
+    "EnableSeleniumLogs": __BrowserStackSettings.EnableSeleniumLogs__,
     "Username": "__BrowserStackSettings.Username__",
-    "AccessKey": "__BrowserStackSettings.AccessKey__",
-    "WebdriverRemoteServerUrl": "__BrowserStackSettings.WebdriverRemoteServerUrl__",
-    "BrowserVersion": "__BrowserStackSettings.BrowserVersion__"
-  },
-  "EnvironmentSettings": {
-    "EnvironmentName": "__EnvironmentSettings.EnvironmentName__",
-    "OperatingSystem": "__EnvironmentSettings.OperatingSystem__",
-    "OperatingSystemVersion": "__EnvironmentSettings.OperatingSystemVersion__",
-    "ScreenResolution": "__EnvironmentSettings.ScreenResolution__"
+    "AccessKey": "__BrowserStackSettings.AccessKey__"
   },
   "ProjectSettings": {
     "AppUrl": "__ProjectSettings.AppUrl__",

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -22,9 +22,8 @@
     "Username": "__BrowserStackSettings.Username__",
     "AccessKey": "__BrowserStackSettings.AccessKey__"
   },
-  "ProjectSettings": {
-    "AppUrl": "__ProjectSettings.AppUrl__",
-    "AppName": "__ProjectSettings.AppName__"
+  "AppSettings": {
+    "AppUrl": "__ProjectSettings.AppUrl__"
   },
   "TestExecutionSettings": {
     "TakeScreenshots": "__TestExecutionSettings.TakeScreenshots__",

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -6,13 +6,13 @@
       "InHeadless": __BrowserSettings.BrowserArguements.InHeadless__
     },
     "UseProxy": __BrowserSettings.UseProxy__,
-    "ProxyUri": "__BrowserSettings.ProxyUri__"
+    "Proxy": "__BrowserSettings.ProxyUri__"
   },
   "BrowserStackSettings": {
     "EnableNetworkLogs": "__BrowserStackSettings.EnableNetworkLogs__",
-    "BrowserStackUsername": "__BrowserStackSettings.BrowserStackUsername__",
-    "BrowserStackPassword": "__BrowserStackSettings.BrowserStackPassword__",
-    "RemoteAddressUri": "__BrowserStackSettings.RemoteAddressUri__",
+    "Username": "__BrowserStackSettings.BrowserStackUsername__",
+    "AccessKey": "__BrowserStackSettings.BrowserStackPassword__",
+    "WebdriverRemoteServerUrl": "__BrowserStackSettings.RemoteAddressUri__",
     "BrowserVersion": "__BrowserStackSettings.BrowserVersion__"
   },
   "EnvironmentSettings": {

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -6,13 +6,13 @@
       "InHeadless": __BrowserSettings.BrowserArguements.InHeadless__
     },
     "UseProxy": __BrowserSettings.UseProxy__,
-    "Proxy": "__BrowserSettings.ProxyUri__"
+    "Proxy": "__BrowserSettings.Proxy__"
   },
   "BrowserStackSettings": {
     "EnableNetworkLogs": "__BrowserStackSettings.EnableNetworkLogs__",
-    "Username": "__BrowserStackSettings.BrowserStackUsername__",
-    "AccessKey": "__BrowserStackSettings.BrowserStackPassword__",
-    "WebdriverRemoteServerUrl": "__BrowserStackSettings.RemoteAddressUri__",
+    "Username": "__BrowserStackSettings.Username__",
+    "AccessKey": "__BrowserStackSettings.AccessKey__",
+    "WebdriverRemoteServerUrl": "__BrowserStackSettings.WebdriverRemoteServerUrl__",
     "BrowserVersion": "__BrowserStackSettings.BrowserVersion__"
   },
   "EnvironmentSettings": {

--- a/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
+++ b/DFC.App.ContactUs.UI.FunctionalTests/appsettings.template.json
@@ -1,7 +1,6 @@
 ﻿{
   "BrowserSettings": {
     "BrowserName": "__BrowserSettings.BrowserName__",
-    "BrowserVersion": "__BrowserSettings.BrowserVersion__",
     "BrowserArguments": {
       "InSandbox": __BrowserSettings.BrowserArguements.InSandbox__,
       "InHeadless": __BrowserSettings.BrowserArguements.InHeadless__
@@ -10,12 +9,11 @@
     "ProxyUri": "__BrowserSettings.ProxyUri__"
   },
   "BrowserStackSettings": {
-    "EnableNetworkLogs": __BrowserStackSettings.EnableNetworkLogs__,
+    "EnableNetworkLogs": "__BrowserStackSettings.EnableNetworkLogs__",
     "BrowserStackUsername": "__BrowserStackSettings.BrowserStackUsername__",
     "BrowserStackPassword": "__BrowserStackSettings.BrowserStackPassword__",
-    "Timezone": "__BrowserStackSettings.Timezone__",
-    "BaseUri": "__BrowserStackSettings.BaseUri__",
-    "RemoteAddressUri": "__BrowserStackSettings.RemoteAddressUri__"
+    "RemoteAddressUri": "__BrowserStackSettings.RemoteAddressUri__",
+    "BrowserVersion": "__BrowserStackSettings.BrowserVersion__"
   },
   "EnvironmentSettings": {
     "EnvironmentName": "__EnvironmentSettings.EnvironmentName__",


### PR DESCRIPTION
- Removed the environment settings (as the settings were moved to the BrowserStack settings)
- Removed logic surrounding the set up of the remote webdriver for BrowserStack.
- Removed the send message logic for BrowserStack during tear down on a failed test run. This message sending logic is not understood and will be implemented when there is a business need.
- Updated nuget version for the UI framework.